### PR TITLE
Fixing easymock version in gradle config.

### DIFF
--- a/lab/build.gradle
+++ b/lab/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         springBootVersion = "3.3.1"
-        easyMockVersion = "5.2"
+        easyMockVersion = "5.2.0"
         jmonVersion = "2.82"
     }
 


### PR DESCRIPTION
The dependency for easymock version 5.2 does not exists. Maven also uses 5.2.0 version.